### PR TITLE
Add missing __init__.py to make opendrift_tools importable

### DIFF
--- a/opendrift_tools/__init__.py
+++ b/opendrift_tools/__init__.py
@@ -1,0 +1,1 @@
+# This file marks this directory as a Python package


### PR DESCRIPTION
This PR adds an __init__.py file to the opendrift_tools directory so it can be treated as an importable Python package. This resolves import errors when using modules from this folder.